### PR TITLE
Define stoppage flag before frame update

### DIFF
--- a/footy_pro.py
+++ b/footy_pro.py
@@ -880,6 +880,8 @@ class Match:
         if not self.pr:
             return
 
+        in_stoppage = bool(self.restart) and self.deadball_timer > 0.0
+
         # --- team shape steering ---
         directives = {}
         ball_point = (self.ball[0], self.ball[1])


### PR DESCRIPTION
## Summary
- define the in_stoppage flag at the start of Match.frame_update using the restart state
- avoid the NameError that occurred while a restart countdown was active

## Testing
- python -m compileall footy_pro.py

------
https://chatgpt.com/codex/tasks/task_e_68e623022f98832bb488ac7e66b8383c